### PR TITLE
Fix nginx start

### DIFF
--- a/overlay/usr/local/bin/cozy-init
+++ b/overlay/usr/local/bin/cozy-init
@@ -26,6 +26,7 @@ EOF
 
 dpkg-reconfigure -u -p high postfix
 apt-get install -y cozy cozy-nginx
+service nginx restart
 
 apt-get clean
 


### PR DESCRIPTION
Seems nginx is not started on C1 instance (no problem on VC1).
Problem on IPv6 during the boot (unable to listen to [::]:80).
So restart nginx at the end.